### PR TITLE
reduce repaints on root embed element

### DIFF
--- a/src/css/chat.css
+++ b/src/css/chat.css
@@ -36,7 +36,7 @@
     transition: transform 0.3s cubic-bezier(0.16, 0.22, 0.22, 1.7);
 
     &.is-collapsed:not(.is-loading) {
-      transform: translateX(110%);
+      transform: translateX(110%) translateZ(0);
     }
 
     /* Add some "extension" so that there isn't a gap

--- a/src/css/chat.css
+++ b/src/css/chat.css
@@ -31,7 +31,8 @@
     background-color: var(--background-color);
     border-left: 1px solid #333;
     box-shadow: -12px 0 18px 0 rgba(50, 50, 50, 0.3);
-
+    
+    transform: translateZ(0);
     transition: transform 0.3s cubic-bezier(0.16, 0.22, 0.22, 1.7);
 
     &.is-collapsed:not(.is-loading) {


### PR DESCRIPTION
The embed element is `position: fixed` which causes it to get repainted on the CPU whenever you scroll, `transform: translateZ(0);` should push that work to the GPU.