### PR TITLE
Do not override "Array.from" with shim version if it is available.

### DIFF
--- a/src/lib/chat.js
+++ b/src/lib/chat.js
@@ -1,5 +1,7 @@
 import {shim as arrayFromShim} from 'array.from';
-arrayFromShim();
+if (!Array.from) {
+  arrayFromShim();
+}
 import objectAssign from 'object-assign';
 import {Promise} from 'es6-promise';
 import Symbol from './basic-symbol-ponyfill';


### PR DESCRIPTION
Because the following code does not work with the "Array.from" version of shim:

```js
Array.from(new Set([1, 2, 3]))
```

**Expected behavior**
[1, 2, 3]

**Actual behavior**
[]