### PR TITLE
use rel="noopener" on external links

### DIFF
--- a/src/lib/chat.js
+++ b/src/lib/chat.js
@@ -142,6 +142,7 @@ let addActionBar = function(chat) {
     popOutActionElement.setAttribute('aria-label', 'Open Chat in Gitter.im');
     popOutActionElement.setAttribute('href', `${opts.host}${opts.room}`);
     popOutActionElement.setAttribute('target', `_blank`);
+    popOutActionElement.setAttribute('rel', `noopener`);
 
     actionBar.appendChild(popOutActionElement);
 


### PR DESCRIPTION
> When your page links to another page using target="_blank", the new page runs on the same process as your page. If the new page is executing expensive JavaScript, your page's performance may also suffer.

Source: https://developers.google.com/web/tools/lighthouse/audits/noopener

Vice versa is also true. If my site (https://isomorphic-git.org) is doing some intense blocking JavaScript and hangs, it could freeze the Gitter.im page. This PR should fix that.
